### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $.find(element).not(this.settings.ignore)[0];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/catalinb19/OnlineLibrary_SE/security/code-scanning/5](https://github.com/catalinb19/OnlineLibrary_SE/security/code-scanning/5)

To fix the problem, we need to ensure that any user-provided input used in jQuery selectors is properly sanitized to prevent XSS attacks. This can be achieved by using jQuery's `find` method instead of directly using the `$` function, which interprets strings starting with `<` as HTML.

- Replace the direct use of `$(element)` with `$.find(element)` to ensure the input is always treated as a CSS selector.
- Update the `validationTargetFor` function to use `$.find` instead of `$`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
